### PR TITLE
Add homepage skeleton

### DIFF
--- a/src/features/Posts/Posts.js
+++ b/src/features/Posts/Posts.js
@@ -4,6 +4,7 @@ import {
 	selectAllPosts,
 	selectPostsStatus,
 	selectPostsError,
+	fetchPosts,
 } from "./postsSlice";
 
 const FrontPage = () => {
@@ -14,8 +15,9 @@ const FrontPage = () => {
 
 	useEffect(() => {
 		if (postsStatus === "idle") {
-			dispatch(fetchFrontPagePosts());
+			dispatch(fetchPosts());
 		}
+		console.log(allPosts);
 	}, [dispatch, postsStatus]);
 
 	return <div>FrontPage</div>;

--- a/src/features/Posts/Posts.js
+++ b/src/features/Posts/Posts.js
@@ -7,7 +7,7 @@ import {
 	fetchPosts,
 } from "./postsSlice";
 
-const FrontPage = () => {
+const Posts = () => {
 	const dispatch = useDispatch();
 	const allPosts = useSelector(selectAllPosts);
 	const postsStatus = useSelector(selectPostsStatus);
@@ -20,7 +20,7 @@ const FrontPage = () => {
 		console.log(allPosts);
 	}, [dispatch, postsStatus]);
 
-	return <div>FrontPage</div>;
+	return <div>Posts</div>;
 };
 
-export default FrontPage;
+export default Posts;

--- a/src/features/Posts/Posts.js
+++ b/src/features/Posts/Posts.js
@@ -1,4 +1,24 @@
-export default function Posts() {
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import {
+	selectAllPosts,
+	selectPostsStatus,
+	selectPostsError,
+} from "./postsSlice";
 
-  return ();
-}
+const FrontPage = () => {
+	const dispatch = useDispatch();
+	const allPosts = useSelector(selectAllPosts);
+	const postsStatus = useSelector(selectPostsStatus);
+	const postsError = useSelector(selectPostsError);
+
+	useEffect(() => {
+		if (postsStatus === "idle") {
+			dispatch(fetchFrontPagePosts());
+		}
+	}, [dispatch, postsStatus]);
+
+	return <div>FrontPage</div>;
+};
+
+export default FrontPage;

--- a/src/features/Posts/postsSlice.js
+++ b/src/features/Posts/postsSlice.js
@@ -1,13 +1,10 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import Reddit from "../../util/Reddit";
 
-export const fetchPosts = createAsyncThunk(
-	"frontPage/fetchFrontPage",
-	async () => {
-		const response = await Reddit.fetchFrontPage();
-		return response;
-	}
-);
+export const fetchPosts = createAsyncThunk("posts/fetchPosts", async () => {
+	const response = await Reddit.fetchPosts();
+	return response;
+});
 
 const initialState = {
 	posts: {},

--- a/src/features/Posts/postsSlice.js
+++ b/src/features/Posts/postsSlice.js
@@ -1,23 +1,52 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import Reddit from "../../util/Reddit";
+
+export const fetchPosts = createAsyncThunk(
+	"frontPage/fetchFrontPage",
+	async () => {
+		const response = await Reddit.fetchFrontPage();
+		return response;
+	}
+);
 
 const initialState = {
-    posts: {
-    },
-    before: "",
-    after: "",
-    loading: false,
-    error: false,
+	posts: {},
+	before: "",
+	after: "",
+	// My thinking here is that the status doesn't need to be a loading Boolean, it can equally be a string to reflect the status of the fetch request
+	status: "idle", // 'idle' || 'loading' || 'succeeded' || 'failed'
+	// Same with the error status, it doesn't need to be a boolean, it can be a message which is the action.payload of the error message.
+	error: null,
 };
 
 const postsSlice = createSlice({
-  name: "posts",
-  initialState,
-  reducers: {
-
-  }
+	name: "posts",
+	initialState,
+	reducers: {},
+	extraReducers: (builder) => {
+		builder
+			.addCase(fetchPosts.pending, (state) => {
+				state.status = "loading";
+			})
+			.addCase(fetchPosts.fulfilled, (state, action) => {
+				state.status = "succeeded";
+				state.posts.posts = action.payload.children;
+				state.nextPage = action.payload.after;
+				state.prevPage = action.payload.before;
+			})
+			.addCase(fetchPosts.rejected, (state, action) => {
+				state.status = "failed";
+				state.error = action.error.message;
+			});
+	},
 });
 
-// export const selectAllPosts = (state) => state.cards.cards;
-// export const { functions } = cardsSlice.actions;
+export const selectAllPosts = (state) => state.posts.posts;
+
+export const selectPostsStatus = (state) => state.posts.status;
+
+export const selectPostsError = (state) => state.posts.error;
+
+export const {} = postsSlice.actions;
 
 export default postsSlice.reducer;


### PR DESCRIPTION
I can't really test this yet because it relies on the reddit functions which are in a previous pull request.

Basically this adds the dispatch and the selectors to the posts feature, so it takes the exports from the slice and imports them but it doesn't do anything with the data yet.